### PR TITLE
centos7 to rockylinux9

### DIFF
--- a/sp/Dockerfile
+++ b/sp/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos7
+FROM rockylinux:9
 
 # Shibboleth IdPのメタデータ取得先のURLを定義する。
 ENV IDP_METADATA_URL=https://idp.example.org/idp/shibboleth

--- a/sp/bin/init.sh
+++ b/sp/bin/init.sh
@@ -23,5 +23,9 @@ chmod +x /etc/shibboleth/shibd-redhat
 echo "$SSH_PASSWD" | chpasswd
 /usr/sbin/sshd &
 
+# php-fpm を起動する。
+[ ! -d /run/php-fpm ] && mkdir /run/php-fpm
+/usr/sbin/php-fpm
+
 # Apacheを起動する。
 exec httpd -DFOREGROUND

--- a/sp/bin/mod-conf.sh
+++ b/sp/bin/mod-conf.sh
@@ -6,6 +6,9 @@ if [ -e /tmp/certs/server.crt -a -e /tmp/certs/server.key ]; then
   mv -f /tmp/certs/server.key /etc/pki/tls/private/localhost.key
 fi
 
+# 証明書ファイルが無ければ生成する
+[ -x /usr/libexec/httpd-ssl-gencerts ] && /usr/libexec/httpd-ssl-gencerts
+
 # httpsの待受ポートを10443に変更する。
 sed -i -e 's/Listen 443 https/Listen 10443 https/g' /etc/httpd/conf.d/ssl.conf 
 sed -i -e 's/<VirtualHost _default_:443>/<VirtualHost _default_:10443>/g' /etc/httpd/conf.d/ssl.conf

--- a/sp/repo/shibboleth.repo
+++ b/sp/repo/shibboleth.repo
@@ -2,7 +2,7 @@
 name=Shibboleth (CentOS_7)
 # Please report any problems to https://issues.shibboleth.net
 type=rpm-md
-mirrorlist=https://shibboleth.net/cgi-bin/mirrorlist.cgi/CentOS_7
+mirrorlist=https://shibboleth.net/cgi-bin/mirrorlist.cgi/rockylinux9
 gpgcheck=1
 gpgkey=https://shibboleth.net/downloads/service-provider/RPMS/repomd.xml.key
         https://shibboleth.net/downloads/service-provider/RPMS/cantor.repomd.xml.key


### PR DESCRIPTION
便利なコンテナ環境の提供ありがとうございます。
利用させて頂こうとしたところいくつかエラーが発生したので、手元で動くように修正をしました。

## 動作確認環境
* Docker Compose version v2.31.0-desktop.2
* Docker version 27.4.0, build bde2b89
* macOS 15.2

## 変更点

### SP の親イメージを centos7 から rockylinux9 へ変更 b3ba7ec
親イメージとして centos7 を利用していると、 `yum` で mirrorlist.centos.org にアクセスしようとして名前解決ができずエラーで終了していました。centos8 でも同じエラーが出たので、rockylinux9 へ変更して解決しました。

### php-fpm を起動 5c3c050
mod_php が非推奨になっているようで、php-fpm を起動するようにしました。

### SP の apache 用のサーバ証明書を自動作成 fb68aa6
sp/certs/ の下に server.{key,crt} を置いて docker build すれば良いようですが、sp/certs/ の下が空のまま build すると、コンテナ起動時に apache がエラーで起動しませんでした。
`systemctl start httpd` で起動すると依存関係により実行される `/usr/libexec/httpd-ssl-gencerts` を、build 時に明示的に実行するようにしました。
